### PR TITLE
Fix runtime selection (don't use compat when system glibc is same version as bundled)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+# This is a reusable workflow. It is NOT triggered directly by Git events.
+# It is called by other workflows to perform the build and test steps.
+name: "Build and run tests"
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Ensure all matrix jobs run, even if one fails
+      matrix:
+        TARGET_ARCH: [ i386, x86_64, gnueabihf, aarch64 ]
+        BUILD_TYPE: [ Debug, Release ]
+    env:
+      BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
+      TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
+
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.BUILD_TYPE }} for ${{ matrix.TARGET_ARCH }}
+        run: ./tooling/build-in-docker.sh ${{ matrix.BUILD_TYPE }}
+
+      - name: Test ${{ matrix.BUILD_TYPE }} for ${{ matrix.TARGET_ARCH }}
+        if: ${{ matrix.TARGET_ARCH == 'x86_64' || matrix.TARGET_ARCH == 'i386' }}
+        run: ./tooling/test-in-docker.sh ${{ matrix.BUILD_TYPE }}
+
+      - name: Rename artifacts
+        run: |
+          cd "cmake-build-${{ matrix.BUILD_TYPE }}-${{ matrix.TARGET_ARCH }}/src/"
+          sudo mv "apprun/AppRun" "apprun/AppRun-${{ matrix.BUILD_TYPE }}-${{ matrix.TARGET_ARCH }}"
+          sudo mv "hooks/libapprun_hooks.so" "hooks/libapprun_hooks-${{ matrix.BUILD_TYPE }}-${{ matrix.TARGET_ARCH }}.so"
+
+      - name: Upload AppRun artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "AppRun-${{ matrix.BUILD_TYPE }}-${{ matrix.TARGET_ARCH }}"
+          path: "cmake-build-${{ matrix.BUILD_TYPE }}-${{ matrix.TARGET_ARCH }}/src/apprun/AppRun-${{ matrix.BUILD_TYPE }}-${{ matrix.TARGET_ARCH }}"
+          retention-days: 7
+
+      - name: Upload libapprun_hooks artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "libapprun_hooks-${{ matrix.BUILD_TYPE }}-${{ matrix.TARGET_ARCH }}.so"
+          path: "cmake-build-${{ matrix.BUILD_TYPE }}-${{ matrix.TARGET_ARCH }}/src/hooks/libapprun_hooks-${{ matrix.BUILD_TYPE }}-${{ matrix.TARGET_ARCH }}.so"
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,43 +1,17 @@
-name: "build"
+name: "CI Build"
 
 on:
   push:
+    # Run on all branches except master, which is handled by the prerelease workflow
     branches-ignore:
-      - master
-    tags-ignore:
-      - 'v*'
+      - 'master'
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        TARGET_ARCH: [ i386, x86_64, gnueabihf, aarch64 ]
-        BUILD_TYPE: [ Debug, Release ]
-    env:
-      BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
-      TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build ${{ matrix.BUILD_TYPE }} ${{ matrix.TARGET_ARCH }}
-        run: tooling/build-in-docker.sh ${{ env.BUILD_TYPE }}
-
-      - name: Test ${{ matrix.BUILD_TYPE }} ${{ matrix.TARGET_ARCH }}
-        if: ${{ env.TARGET_ARCH == 'x86_64' || env.TARGET_ARCH == 'i386' }}
-        run: tooling/test-in-docker.sh ${{ env.BUILD_TYPE }}
-
-      - name: Prepare artifacts
-        shell: bash
-        working-directory: cmake-build-${{ env.BUILD_TYPE }}-${{ env.TARGET_ARCH }}
-        run: |
-          mkdir -p ${{runner.workspace}}/dist
-          cp src/apprun/AppRun ${{runner.workspace}}/dist/AppRun-$BUILD_TYPE-$TARGET_ARCH
-          cp src/hooks/libapprun_hooks.so ${{runner.workspace}}/dist/libapprun_hooks-$BUILD_TYPE-$TARGET_ARCH.so
-
-      - name: Upload Artifacts ${{ env.TARGET_ARCH }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts
-          path: ${{runner.workspace}}/dist/*
+  build-and-test:
+    name: "Build and test"
+    uses: ./.github/workflows/build.yml
+    # Note: secrets must be explicitly passed to reusable workflows if needed.
+    # secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build ${{ matrix.BUILD_TYPE }} ${{ matrix.TARGET_ARCH }}
         run: tooling/build-in-docker.sh ${{ env.BUILD_TYPE }}
@@ -37,7 +37,7 @@ jobs:
           cp src/hooks/libapprun_hooks.so ${{runner.workspace}}/dist/libapprun_hooks-$BUILD_TYPE-$TARGET_ARCH.so
 
       - name: Upload Artifacts ${{ env.TARGET_ARCH }}
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: ${{runner.workspace}}/dist/*

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -17,7 +17,7 @@ jobs:
       TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build ${{ matrix.BUILD_TYPE }} ${{ matrix.TARGET_ARCH }}
         run: tooling/build-in-docker.sh ${{ env.BUILD_TYPE }}
@@ -35,7 +35,7 @@ jobs:
           cp src/hooks/libapprun_hooks.so ${{runner.workspace}}/dist/libapprun_hooks-$BUILD_TYPE-$TARGET_ARCH.so
 
       - name: Upload Artifacts ${{ env.TARGET_ARCH }}
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: ${{runner.workspace}}/dist/*
@@ -45,7 +45,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifacts from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: artifacts
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,61 +1,33 @@
-name: "pre-release"
+name: "Pre-release"
 
 on:
   push:
     branches:
       - "master"
+  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        TARGET_ARCH: [ i386, x86_64, gnueabihf, aarch64 ]
-        BUILD_TYPE: [ Debug, Release ]
-    env:
-      BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
-      TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build ${{ matrix.BUILD_TYPE }} ${{ matrix.TARGET_ARCH }}
-        run: tooling/build-in-docker.sh ${{ env.BUILD_TYPE }}
-
-      - name: Test ${{ matrix.BUILD_TYPE }} ${{ matrix.TARGET_ARCH }}
-        if: ${{ env.TARGET_ARCH == 'x86_64' || env.TARGET_ARCH == 'i386' }}
-        run: tooling/test-in-docker.sh ${{ env.BUILD_TYPE }}
-
-      - name: Prepare artifacts
-        shell: bash
-        working-directory: cmake-build-${{ env.BUILD_TYPE }}-${{ env.TARGET_ARCH }}
-        run: |
-          mkdir -p ${{runner.workspace}}/dist
-          cp src/apprun/AppRun ${{runner.workspace}}/dist/AppRun-$BUILD_TYPE-$TARGET_ARCH
-          cp src/hooks/libapprun_hooks.so ${{runner.workspace}}/dist/libapprun_hooks-$BUILD_TYPE-$TARGET_ARCH.so
-
-      - name: Upload Artifacts ${{ env.TARGET_ARCH }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts
-          path: ${{runner.workspace}}/dist/*
+    name: "Run Build and Test Matrix"
+    uses: ./.github/workflows/build.yml
 
   publish:
+    name: "Publish Pre-release"
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Download artifacts from build job
+      - name: Download all build artifacts from build job
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          pattern: "*"
+          path: release-assets
+          merge-multiple: true
 
-      - name: Release In-Development AppImage
-        uses: marvinpinto/action-automatic-releases@latest
-
+      - name: Create 'continuous' Pre-release
+        uses: softprops/action-gh-release@v2
         with:
-          title: Continuous build
-          automatic_release_tag: 'continuous'
+          files: release-assets/*
+          tag_name: "continuous"
+          name: "Continuous Build (Pre-release)"
+          body: "This is a continuous build which may be unstable."
           prerelease: true
-          draft: false
-          files: ./*
-          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,56 +1,30 @@
-name: "tagged-release"
+name: "Tagged Release"
 
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        TARGET_ARCH: [ i386, x86_64, gnueabihf, aarch64 ]
-        BUILD_TYPE: [ Debug, Release ]
-    env:
-      BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
-      TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
-
-    steps:
-      - uses: actions/checkout@4
-
-      - name: Build ${{ matrix.BUILD_TYPE }} ${{ matrix.TARGET_ARCH }}
-        run: tooling/build-in-docker.sh ${{ env.BUILD_TYPE }}
-
-      - name: Test ${{ matrix.BUILD_TYPE }} ${{ matrix.TARGET_ARCH }}
-        if: ${{ env.TARGET_ARCH == 'x86_64' || env.TARGET_ARCH == 'i386' }}
-        run: tooling/test-in-docker.sh ${{ env.BUILD_TYPE }}
-
-      - name: Prepare artifacts
-        shell: bash
-        working-directory: cmake-build-${{ env.BUILD_TYPE }}-${{ env.TARGET_ARCH }}
-        run: |
-          mkdir -p ${{runner.workspace}}/dist
-          cp src/apprun/AppRun ${{runner.workspace}}/dist/AppRun-$BUILD_TYPE-$TARGET_ARCH
-          cp src/hooks/libapprun_hooks.so ${{runner.workspace}}/dist/libapprun_hooks-$BUILD_TYPE-$TARGET_ARCH.so
-
-      - name: Upload Artifacts ${{ env.TARGET_ARCH }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts
-          path: ${{runner.workspace}}/dist/*
+    name: "Run Build and Test Matrix"
+    uses: ./.github/workflows/reusable-build.yml
 
   publish:
+    name: "Publish Tagged Release"
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Download artifacts from build job
+      - name: Download all build artifacts from build job
         uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          pattern: "*"
+          path: release-assets
+          merge-multiple: true
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          files: release-assets/*
           prerelease: false
-          files: ./*

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -17,7 +17,7 @@ jobs:
       TARGET_ARCH: ${{ matrix.TARGET_ARCH }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@4
 
       - name: Build ${{ matrix.BUILD_TYPE }} ${{ matrix.TARGET_ARCH }}
         run: tooling/build-in-docker.sh ${{ env.BUILD_TYPE }}
@@ -35,7 +35,7 @@ jobs:
           cp src/hooks/libapprun_hooks.so ${{runner.workspace}}/dist/libapprun_hooks-$BUILD_TYPE-$TARGET_ARCH.so
 
       - name: Upload Artifacts ${{ env.TARGET_ARCH }}
-        uses: actions/upload-artifact@v2.1.4
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: ${{runner.workspace}}/dist/*
@@ -45,7 +45,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifacts from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: artifacts
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cmake-build-*
 .idea
+build/

--- a/src/apprun/runtime_interpreter.c
+++ b/src/apprun/runtime_interpreter.c
@@ -204,7 +204,7 @@ void setup_runtime() {
         fprintf(stderr, "APPRUN_DEBUG: system ld(%s), appdir ld(%s) \n", system_ld_version, appdir_ld_version);
 #endif
         char *runtime_path = NULL;
-        if (compare_version_strings(system_ld_version, appdir_ld_version) > 0) {
+        if (compare_version_strings(system_ld_version, appdir_ld_version) >= 0) {
             runtime_path = resolve_runtime_path("runtime/default");
             configure_system_libc();
         } else {


### PR DESCRIPTION
Also, update CI workflows:
- A lot of DRY.
- Stop using deprecated actions and outdated versions of the undeprecated ones.